### PR TITLE
Update Physics Model

### DIFF
--- a/Fitter/python/AnomalousCouplingEFTNegative.py
+++ b/Fitter/python/AnomalousCouplingEFTNegative.py
@@ -16,20 +16,10 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
         self.mHRange = []
         self.poiNames = []
         self.alternative = False
-        self.numOperators={}
-        self.Operators={}
-        # jsons=open(os.environ['CMSSW_BASE']+'/src/EFTFit/Fitter/hist_files/selectedWCs.txt','r').read()
-
-        # operators=json.loads(jsons)
+        self.verbose = False
+        self.numOperators = {}
+        self.Operators = {}
         self.sgnl_known = ['ttH','tllq','ttll','ttlnu','tHq','tttt']
-        # self.alloperators=[]
-        # for sig in self.sgnl_known:
-            # self.Operators[sig] = operators[sig]
-            # self.numOperators[sig]=len(operators[sig])
-            # self.alloperators.extend(operators[sig])
-        # self.alloperators=list(set(self.alloperators))
-        # print(self.Operators)
-        
 
         # regular expressions for process names:
         self.sm_re    = re.compile('(?P<proc>.*)_sm')
@@ -50,7 +40,9 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
         self.alloperators = list(set(self.alloperators))
         print("Operators: {ops}".format(ops=self.Operators))
 
+
     def setPhysicsOptions(self,physOptions):
+        """ Handle any physics options specified by the user."""
         selected_wcs_fpath = os.path.join(os.environ['CMSSW_BASE'],'src/EFTFit/Fitter/hist_files/selectedWCs.txt')  # Default
         for po in physOptions:
             if po.startswith("eftAlternative"):
@@ -58,170 +50,161 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
                 raise RuntimeError("Alternative not yet implemented")
             if po.startswith("selectedWCs="):
                 selected_wcs_fpath = po.replace("selectedWCs=","").strip()
+            if po.startswith("verbose"):
+                self.verbose = True
         self.loadOperators(selected_wcs_fpath) 
 
 
-#
-# Define parameters of interest
-#
-
     def doParametersOfInterest(self):
-        """Create POI and other parameters, and define the POI set."""
-
+        """ Create POI and other parameters, and define the POI set."""
         self.modelBuilder.doVar("r[1,-10,10]")
         self.poiNames = "r"
-
-        self.quadFactors=[]
+        self.quadFactors = []
 
         for operator in self.alloperators:
-          self.modelBuilder.doVar(operator + "[0,-200,200]")
-          self.poiNames += "," + operator
+            self.modelBuilder.doVar(operator + "[0,-200,200]")
+            self.poiNames += "," + operator
 
-
-
-        for sig in self.sgnl_known:  
+        # This is the pure SM contribution
+        for sig in self.sgnl_known:
+            sgnl_ops = self.Operators[sig]
             if self.numOperators[sig] != 1:
-                
-              for op in self.Operators[sig]:
-                  oplist=self.Operators[sig][self.Operators[sig].index( op ):]
-                  formula='@0' + ' '.join([ '-@0*@%d'%(i+1) for i in range(len(oplist[1:]))])
-            
-                  self.modelBuilder.factory_(
-                      "expr::func_{sig}_sm_{op}(\"{formula}\", {oplist})".format( sig=sig, op = op, formula=formula, oplist=','.join(oplist))
-                  )
-
-              self.modelBuilder.factory_(
-                  "expr::func_%s_sm(\"@0*(1-@%s)\", 1, %s)"%(sig,'-@'.join(str(i+1) for i in range(len(self.Operators[sig]))), 
-                                                             ", ".join('func_%s_sm_'%(sig)+op for op in self.Operators[sig]))
-              )
-              
-            
-            else :
-              self.modelBuilder.factory_(
-                   "expr::func_%s_sm(\"@0*(1-("%(sig) +
-                                            "@1" +
-                                            "))\", 1," + "" + str(self.Operators[sig][0]) + ")"
-                   )
-
-
-
-        #
-        # this is the coefficient of "SM + Lin_i + Quad_i"
-        #
-
-        for sig in self.sgnl_known:  
-            if self.numOperators[sig] != 1:
-                for operator in range(0, self.numOperators[sig]):
-                    
-                    self.modelBuilder.factory_(
-                        "expr::func_%s_sm_linear_quadratic_"%sig + str(self.Operators[sig][operator]) +
-                        "(\"@0*(" +
-                        "@1 * (1-(" + "@" + "+@".join( [str(j+2) for j in range(len(self.Operators[sig]) -1) ] ) + ") )" +
-                        ")\", 1," + str(self.Operators[sig][operator]) +
-                        ", " + ", ".join( [str(self.Operators[sig][j]) for j in range(len(self.Operators[sig])) if operator!=j ] ) +
-                        ")"
+                for op in sgnl_ops:
+                    op_idx = sgnl_ops.index(op)
+                    oplist = sgnl_ops[op_idx:]
+                    terms = " ".join(['-@0*@%d'%(i+1) for i,x in enumerate(oplist[1:])])
+                    formula = "@0{}".format(terms)
+                    expression = "expr::func_{sig}_sm_{op}(\"{formula}\", {oplist})".format(
+                        sig=sig,
+                        op=op,
+                        formula=formula,
+                        oplist=','.join(oplist)
                     )
-            else :
-            
-              self.modelBuilder.factory_(
-                      "expr::func_%s_sm_linear_quadratic_"%sig + str(self.Operators[sig][0]) +
-                                 "(\"@0*(" +
-                                 "@1" +
-                                 ")\", 1," + str(self.Operators[sig][0]) +
-                                 ")"
-                      )
+                    if self.verbose:
+                        print("SM sub-expr: {}".format(expression))
+                    self.modelBuilder.factory_(expression)
+                terms = "-@".join(str(i+1) for i,x in enumerate(sgnl_ops))
+                formula = "@0*(1-@{})".format(terms)
+                functions = ", ".join('func_{sig}_sm_{op}'.format(sig=sig,op=op) for op in self.Operators[sig])
+                expression = "expr::func_{sig}_sm(\"{formula}\", 1, {funcs})".format(
+                    sig=sig,
+                    formula=formula,
+                    funcs=functions
+                )
+                if self.verbose:
+                    print("SM expr: {}".format(expression))
+                self.modelBuilder.factory_(expression)
+            else:
+                formula = "@0*(1-(@1))"
+                expression = "expr::func_{sig}_sm(\"{formula}\", 1, {op})".format(
+                    sig=sig,
+                    formula=formula,
+                    op=sgnl_ops[0]
+                )
+                if self.verbose:
+                    print("SM expr: {}".format(expression))
+                self.modelBuilder.factory_(expression)
 
-          
-        #
-        # quadratic term in each Wilson coefficient
-        #
-        #
+        # This is the coefficient of "SM + Lin_i + Quad_i"
+        for sig in self.sgnl_known:
+            sgnl_ops = self.Operators[sig]
+            if self.numOperators[sig] != 1:
+                for i in range(0,self.numOperators[sig]):
+                    op = sgnl_ops[i]
+                    oplist = [str(sgnl_ops[j]) for j in range(len(sgnl_ops)) if i != j]
+                    terms = "+@".join([str(j+2) for j in range(len(sgnl_ops) - 1)])
+                    formula = "@0*(@1 * (1-(@{terms})))".format(terms=terms)
+                    expression = "expr::func_{sig}_sm_linear_quadratic_{op}(\"{formula}\", 1,{op}, {oplist})".format(
+                        sig=sig,
+                        op=op,
+                        formula=formula,
+                        oplist=", ".join(oplist)
+                    )
+                    if self.verbose:
+                        print("SM+L+Q expr: {}".format(expression))
+                    self.modelBuilder.factory_(expression)
+            else:
+                formula = "@0*(@1)"
+                expression = "expr::func_{sig}_sm_linear_quadratic_(\"{formula}\", 1, {op})".format(
+                    sig=sig,
+                    formula=formula,
+                    op=sgnl_ops[0]
+                )
+                if self.verbose:
+                    print("SM+L+Q expr: {}".format(expression))
+                self.modelBuilder.factory_(expression)
+
+        # Quadratic term in each Wilson coefficient
         # e.g. expr::func_sm_linear_quadratic_cH("@0*(@1 * (1-2*(@2+@3) ))", 1,cH, cG, cGtil)
-        #
         for sig in self.sgnl_known:  
-
-          for operator in range(0, self.numOperators[sig]):
-          
-            #
-            # this is the coefficient of "Quad_i"
-            #
-            
-              self.modelBuilder.factory_("expr::func_%s_quadratic_"%sig+ str(self.Operators[sig][operator]) + "(\"@0*(@1*@1-@1)\", 1," + str(self.Operators[sig][operator]) + ")")
-          
-          
-                                          
-          
-          
-          
-          #
-          # (SM + linear) + quadratic + interference between pairs of Wilson coefficients
-          #
-          
-          if self.numOperators[sig] != 1:
-            for operator in range(0, self.numOperators[sig]):
-              for operator_sub in range(operator+1, self.numOperators[sig]):
-                #
-                # this is the coefficient of "SM + Lin_i + Lin_j + Quad_i + Quad_j + 2 * M_ij"
-                #
-                #print "expr::func_sm_linear_quadratic_mixed_" + str(self.Operators[operator_sub]) + "_" + str(self.Operators[operator]) +          \
-                #"(\"@0*@1*@2\", 1," + str(self.Operators[operator]) + "," + str(self.Operators[operator_sub]) +                      \
-                #")"
-                self.quadFactors.append("func_%s_sm_linear_quadratic_mixed_"%(sig) + str(self.Operators[sig][operator_sub]) + "_" + str(self.Operators[sig][operator]))
-                self.modelBuilder.factory_(
-                        "expr::func_%s_sm_linear_quadratic_mixed_"%(sig) + str(self.Operators[sig][operator_sub]) + "_" + str(self.Operators[sig][operator]) +
-                        "(\"@0*@1*@2\", 1," + str(self.Operators[sig][operator]) + "," + str(self.Operators[sig][operator_sub]) +
-                        ")")
-          
-          
-
-
-        print " parameters of interest = ", self.poiNames
-        print " self.numOperators = ", self.numOperators
-        
+            sgnl_ops = self.Operators[sig]
+            # This is the coefficient of "Quad_i"
+            for i in range(0,self.numOperators[sig]):
+                formula = "@0*(@1*@1-@1)"
+                expression = "expr::func_{sig}_quadratic_{op}(\"{formula}\", 1, {op})".format(
+                    sig=sig,
+                    op=sgnl_ops[i],
+                    formula=formula
+                )
+                if self.verbose:
+                    print("Quad expr: {}".format(expression))
+                self.modelBuilder.factory_(expression)
+            # (SM + linear) + quadratic + interference between pairs of Wilson coefficients
+            if self.numOperators[sig] != 1:
+                for i in range(0, self.numOperators[sig]):
+                    for j in range(i+1,self.numOperators[sig]):
+                        # This is the coefficient of "SM + Lin_i + Lin_j + Quad_i + Quad_j + 2 * M_ij"
+                        func_name = "func_{sig}_sm_linear_quadratic_mixed_{op1}_{op2}".format(
+                            sig=sig,
+                            op1=sgnl_ops[j],    # Note: This is the order as it was before the code cleanup
+                            op2=sgnl_ops[i]
+                        )
+                        self.quadFactors.append(func_name)
+                        formula = "@0*@1*@2"
+                        expression = "expr::{name}(\"{formula}\", 1,{op1},{op2})".format(
+                            name=func_name,
+                            formula=formula,
+                            op1=sgnl_ops[i],
+                            op2=sgnl_ops[j]
+                        )
+                        if self.verbose:
+                            print("Mixed expr: {}".format(expression))
+                        self.modelBuilder.factory_(expression)
+        print(" parameters of interest = {}".format(self.poiNames))
+        print(" self.numOperators = {}".format(self.numOperators))
         self.modelBuilder.doSet("POI",self.poiNames)
 
 
-
-
-
-#
-# Define how the yields change
-#
-
-
     def getYieldScale(self,bin,process):
-
+        """ Define how the yields change."""
         if any( process.startswith(x) for x in self.sgnl_known):
             if self.sm_re.search(process):
-                match=self.sm_re.search(process)
-                return "func_%s_sm"%(match.group('proc'))
+                match = self.sm_re.search(process)
+                return "func_{p}_sm".format(p=match.group('proc'))
             elif self.lin_re.search(process): 
-                match=self.lin_re.search(process)
-                return "func_%s_sm_linear_quadratic_"%(match.group('proc'))+ match.group('c1')
+                match = self.lin_re.search(process)
+                return "func_{p}_sm_linear_quadratic_{c1}".format(p=match.group('proc'),c1=match.group('c1'))
             elif self.mixed_re.search(process):
-                match=self.mixed_re.search(process)
-                c1=match.group('c1')
-                c2=match.group('c2')
-                proc=match.group('proc')
-                if "func_%s_sm_linear_quadratic_mixed_"%(proc) + c1 + "_" + c2 in self.quadFactors:
-                    return "func_%s_sm_linear_quadratic_mixed_"%(proc) + c1 + "_" + c2
+                match = self.mixed_re.search(process)
+                c1 = match.group('c1')
+                c2 = match.group('c2')
+                proc = match.group('proc')
+                name = "func_{p}_sm_linear_quadratic_mixed_{c1}_{c2}".format(p=proc,c1=c1,c2=c2)
+                if name in self.quadFactors:
+                    return "func_{p}_sm_linear_quadratic_mixed_{c1}_{c2}".format(p=proc,c1=c1,c2=c2)
                 else:
-                    return "func_%s_sm_linear_quadratic_mixed_"%(proc) + c2 + "_" + c1
-                
-            elif  self.quad_re.search(process):
-                match=self.quad_re.search(process)
-                proc=match.group('proc')
-                c1=match.group('c1')
-                return "func_%s_quadratic_"%(proc)+c1
+                    return "func_{p}_sm_linear_quadratic_mixed_{c2}_{c1}".format(p=proc,c1=c1,c2=c2)
+            elif self.quad_re.search(process):
+                match = self.quad_re.search(process)
+                c1 = match.group('c1')
+                proc = match.group('proc')
+                return "func_{p}_quadratic_{c1}".format(p=proc,c1=c1)
             else:
                 #raise RuntimeError("Undefined process %s"%process)
-                print("Undefined process %s, probably below threshold and ignored"%process)
-
+                print("Undefined process {}, probably below threshold and ignored".format(process))
         else:
-            print 'Process %s not a signal'%process
+            print("Process {} not a signal".format(process))
             return 1
-        
-
 
 #
 #  Standard inputs:

--- a/Fitter/python/AnomalousCouplingEFTNegative.py
+++ b/Fitter/python/AnomalousCouplingEFTNegative.py
@@ -18,17 +18,17 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
         self.alternative = False
         self.numOperators={}
         self.Operators={}
-        jsons=open(os.environ['CMSSW_BASE']+'/src/EFTFit/Fitter/hist_files/selectedWCs.txt','r').read()
+        # jsons=open(os.environ['CMSSW_BASE']+'/src/EFTFit/Fitter/hist_files/selectedWCs.txt','r').read()
 
-        operators=json.loads(jsons)
+        # operators=json.loads(jsons)
         self.sgnl_known = ['ttH','tllq','ttll','ttlnu','tHq','tttt']
-        self.alloperators=[]
-        for sig in self.sgnl_known:
-            self.Operators[sig] = operators[sig]
-            self.numOperators[sig]=len(operators[sig])
-            self.alloperators.extend(operators[sig])
-        self.alloperators=list(set(self.alloperators))
-        print(self.Operators)
+        # self.alloperators=[]
+        # for sig in self.sgnl_known:
+            # self.Operators[sig] = operators[sig]
+            # self.numOperators[sig]=len(operators[sig])
+            # self.alloperators.extend(operators[sig])
+        # self.alloperators=list(set(self.alloperators))
+        # print(self.Operators)
         
 
         # regular expressions for process names:
@@ -38,13 +38,27 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
         self.mixed_re = re.compile('(?P<proc>.*)_quad_mixed_(?P<c1>.*)_(?P<c2>.*)') # should go before quad
 
 
+    def loadOperators(self,fpath):
+        print("Loading operators from {fpath}".format(fpath=fpath))
+        jsn = open(fpath,'r').read()
+        operators = json.loads(jsn)
+        self.alloperators = []
+        for sig in self.sgnl_known:
+            self.Operators[sig] = operators[sig]
+            self.numOperators[sig] = len(operators[sig])
+            self.alloperators.extend(operators[sig])
+        self.alloperators = list(set(self.alloperators))
+        print("Operators: {ops}".format(ops=self.Operators))
+
     def setPhysicsOptions(self,physOptions):
+        selected_wcs_fpath = os.path.join(os.environ['CMSSW_BASE'],'src/EFTFit/Fitter/hist_files/selectedWCs.txt')  # Default
         for po in physOptions:
-
-
             if po.startswith("eftAlternative"):
                 self.alternative = True
                 raise RuntimeError("Alternative not yet implemented")
+            if po.startswith("selectedWCs="):
+                selected_wcs_fpath = po.replace("selectedWCs=","").strip()
+        self.loadOperators(selected_wcs_fpath) 
 
 
 #


### PR DESCRIPTION
This PR adds two new physics options (`--PO`) that can optionally be specified when running `text2workspace` with the `AnaliticAnomalousCouplingEFTNegative` PhysicsModel. The two options are:

- `selectedWCs=`: This option allows the user to specify a file path to a custom `selectedWCs.txt` file. If the option is omitted then the code will continue to use the one provided by the repo
- `verbose`: This option will enable additional print statements that might be useful to cross-check that the correct objects are being created in the workspace

The other and slightly more contentious change included in this PR is that I took this opportunity to clean-up and organize the code a bit. I endeavored to maintain all variable names consistent where relevant and only added new variables in places to try and break up some of the otherwise very long and hard to read lines. I also went through and made the indentation consistent throughout. I did make sure to go and check that a handful of the workspace objects (at least one per `expr::func` "type") appear with the exact same structure and syntax before and after these changes, but I was by no means exhaustive.

Since code clean-up/style updates can be hard to review, I'm fine with us just shelving this PR for now and leaving the branch available for anyone who wants to make use of the changes. All the changes are purely quality of life or aesthetic and should have no impact on the analysis results. 