### PR TITLE
2D plotting changes

### DIFF
--- a/Fitter/scripts/parse_nll.py
+++ b/Fitter/scripts/parse_nll.py
@@ -117,6 +117,8 @@ def get_unique_points(in_dict,scan_var,minimize_var):
     scan_var_val_lst_unique = {}
     for idx in range(ref_len):
         scan_var_val = in_dict[scan_var][idx]
+        if any(isinstance(i, list) for i in in_dict[scan_var]):  #relevant only for 2D scans
+            scan_var_val = tuple(scan_var_val)
         minimize_var_val = in_dict[minimize_var][idx]
         if scan_var_val not in scan_var_val_lst_unique:
             # This x value is not yet in our unique list
@@ -137,7 +139,7 @@ def get_unique_points(in_dict,scan_var,minimize_var):
     idx_to_keep = np.array(idx_to_keep)
     for var_name in in_dict.keys():
         var_val_arr = np.array(in_dict[var_name])
-        var_val_arr_unique = np.take(var_val_arr,idx_to_keep)
+        var_val_arr_unique = var_val_arr[idx_to_keep]
         out_dict[var_name] = list(var_val_arr_unique)
 
     return out_dict


### PR DESCRIPTION
This PR pertains to the changes made to the 2D plotting methods in EFTPlotter script to handle duplicate point removal as a result of implementation of random starting points for 2D scans in MultiDimFit method. There are two main changes here: 

1. In parse_nll.py script, get_unique_points() has been slightly modified to take multiple scan_var_val (instead of just 1 value for 1d plotting)
2. In EFTPlotter.py script, since the way 2D color maps and contour plots are made is slightly different than the way 1D plotting is done, I created a new function that takes multiple grid scan jobs, hadds all the root files, then loops inside the TTree in the hadded root file to select only the grid scan point with the least deltaNLL value. The function then writes these unique points to a new tree which is subsequently written to a new root file called "tmp.root" that is later on used for 2D plottings. 
Both the changes have been tested in multiple cases, and they work as expected. 