### PR TITLE
Editing some scripts to update header paths and cautioning against hardcoded paths

### DIFF
--- a/Fitter/condor/struct_maker_wrapper.py
+++ b/Fitter/condor/struct_maker_wrapper.py
@@ -9,5 +9,6 @@ parser.add_argument('--idx',   '-i', default=0, help = 'Index of the signal regi
 
 args = parser.parse_args()
 root_args = args.idx
-macro_dir = '/afs/crc.nd.edu/user/f/fyan2/macrotesting/CMSSW_10_2_13/src/EFTFit/Fitter/scripts/'
+#CAUTION: Hardcoded path
+macro_dir = '/afs/crc.nd.edu/user/a/abasnet/CMSSW_10_2_13/src/EFTFit/Fitter/scripts/'
 subprocess.check_call(['root','-b','-l','-q', macro_dir + 'struct_maker.C({args})'.format(args=root_args)])

--- a/Fitter/interface/AnalysisCategory.h
+++ b/Fitter/interface/AnalysisCategory.h
@@ -11,6 +11,9 @@
 #include "RooDataSet.h"
 #include "RooCatType.h"
 #include "RooAddition.h"
+#include "HiggsAnalysis/CombinedLimit/interface/CMSHistFunc.h"
+#include "HiggsAnalysis/CombinedLimit/interface/CMSHistErrorPropagator.h"
+#include "HiggsAnalysis/CombinedLimit/interface/CMSHistFuncWrapper.h"
 
 #include "WSHelper.h"
 

--- a/Fitter/interface/PlotData.h
+++ b/Fitter/interface/PlotData.h
@@ -18,6 +18,31 @@
 
 typedef std::vector<TString> vTStr;
 
+
+//Caution: What I have here is a hack. The processes for ttgamma and TOP-22-006 diverged, but I didn't want to get rid of TOP-22-006 related code here. So I made this change where you can choose whether you are running only over ttgamma analysis or TOP-22-006 analysis. In the future, there won't be this distinction, and you might have to revisit this. So, the way it works is if you want to use ttgamma analysis processes, comment out "#define USE_TOP22006_PROCS" and vice-versa
+
+#define USE_TTA_PROCS
+//#define USE_TOP22006_PROCS
+
+#ifdef USE_TTA_PROCS
+vTStr ALL_PROCS {
+    "fakes", "fakePh","Diboson","Triboson","tWZ","ttH","ttll","ttlnu","tllq","tHq","tttt","ttA","ZGISR","ZGFSR","STGamma","Others"
+};
+
+
+vTStr SIG_PROCS {"ttlnu", "ttll", "ttH", "tllq", "tHq", "tttt","ttA"};
+
+vTStr YIELD_TABLE_ORDER {"Diboson","Triboson","fakes","fakePh","ttlnu","ttll","ttH","tllq","tHq","tttt","ttA","ZGISR","ZGFSR","STGamma","Others"};
+
+vTStr BKGD_PROCS {"Diboson", "Triboson", "fakes", "fakePh","ZGISR","ZGFSR","STGamma", "tWZ","Others"};
+
+vTStr SR_list = {"2los_sf_ph","2los_of_ph","2los_ph_CR_sf_Zg"};
+
+std::vector<std::string> kin_list = {"photon_pt"};
+
+#endif
+
+#ifdef USE_TOP22006_PROCS
 vTStr ALL_PROCS {
     "charge_flips","fakes",
     "Diboson","Triboson",
@@ -25,35 +50,56 @@ vTStr ALL_PROCS {
     "ttH","ttll","ttlnu","tllq","tHq","tttt"
 };
 
+vTStr SIG_PROCS {"ttlnu", "ttll", "ttH", "tllq", "tHq", "tttt"};
+
 vTStr YIELD_TABLE_ORDER {
     "Diboson","Triboson","charge_flips","fakes","convs",
     "ttlnu","ttll","ttH","tllq","tHq","tttt"
 };
 
-vTStr WC_list = {"ctW", "ctZ", "ctp", "cpQM", "ctG", "cbW", "cpQ3", 
-                 "cptb", "cpt", "cQl3i", "cQlMi", "cQei", "ctli", 
-                 "ctei", "ctlSi", "ctlTi", "cQq13", "cQq83", "cQq11", 
-                 "ctq1", "cQq81", "ctq8", "ctt1", "cQQ1", "cQt8", "cQt1"};
-
-vTStr SIG_PROCS {"ttlnu", "ttll", "ttH", "tllq", "tHq", "tttt"};
-
 vTStr BKGD_PROCS {"Diboson", "Triboson", "charge_flips", "fakes", "convs", "tWZ"};
 
-vTStr SR_list = {"2lss_p", "2lss_m", "2lss_4t_p", "2lss_4t_m", "3l_p_offZ_1b", "3l_m_offZ_1b", "3l_p_offZ_2b", "3l_m_offZ_2b", "3l_onZ_1b", "3l_onZ_2b", "4l"};
+//vTStr SR_list = {"2lss_p", "2lss_m", "2lss_4t_p", "2lss_4t_m", "3l_p_offZ_1b", "3l_m_offZ_1b", "3l_p_offZ_2b", "3l_m_offZ_2b", "3l_onZ_1b", "3l_onZ_2b", "4l"};
 
-vTStr SR_list_2 = SR_list; // Comment this line and uncomment the line below to split onZ 2b category.
-// vTStr SR_list_2 = {"2lss_p", "2lss_m", "2lss_4t_p", "2lss_4t_m", "3l_p_offZ_1b", "3l_m_offZ_1b", "3l_p_offZ_2b", "3l_m_offZ_2b", "3l_onZ_2b_2j3j", "4l", "3l_onZ_1b", "3l_onZ_2b_4j5j"};
-// vTStr SR_list_2 = {"2lss_p", "2lss_m", "2lss_4t_p", "2lss_4t_m", "3l_p_offZ_1b", "3l_m_offZ_1b", "3l_p_offZ_2b", "3l_m_offZ_2b", "3l_onZ_1b", "3l_onZ_2b_2j3j", "3l_onZ_2b_4j5j", "4l"};
+std::vector<std::string> kin_list = {"lj0pt", "ptz"};
+#endif
+
+vTStr WC_list = {"ctW", "ctZ", "ctp", "cpQM", "ctG", "cbW", "cpQ3",
+                 "cptb", "cpt", "cQl3i", "cQlMi", "cQei", "ctli",
+                 "ctei", "ctlSi", "ctlTi", "cQq13", "cQq83", "cQq11",
+                 "ctq1", "cQq81", "ctq8", "ctt1", "cQQ1", "cQt8", "cQt1"};
+
+//vTStr SR_list = {"2lss_p", "2lss_m", "2lss_4t_p", "2lss_4t_m", "3l_p_offZ_1b", "3l_m_offZ_1b", "3l_p_offZ_2b", "3l_m_offZ_2b", "3l_onZ_1b", "3l_onZ_2b", "4l"};
+
+//vTStr SR_list = {"2lss_p"}; //CHANGED
+
+//vTStr SR_list_2 = SR_list; // Comment this line and uncomment the line below to split onZ 2b category.
+
+//vTStr SR_list = {"2lss_p", "2lss_m", "2lss_4t_p", "2lss_4t_m", "3l_p_offZ_1b", "3l_m_offZ_1b", "3l_p_offZ_2b", "3l_m_offZ_2b", "3l_onZ_2b_2j3j", "4l", "3l_onZ_1b", "3l_onZ_2b_4j5j"};
+//The order we want for TOP-22-006
+//vTStr SR_list = {"2lss_m", "2lss_p", "2lss_4t_m", "2lss_4t_p", "3l_p_offZ_1b", "3l_m_offZ_1b", "3l_p_offZ_2b", "3l_m_offZ_2b", "3l_onZ_1b", "4l","3l_onZ_2b_2j3j","3l_onZ_2b_4j5j"};
+//vTStr SR_list = {"2lss_p", "2lss_m", "2lss_4t_p", "2lss_4t_m", "3l_p_offZ_1b", "3l_m_offZ_1b", "3l_p_offZ_2b", "3l_m_offZ_2b", "3l_onZ_1b", "3l_onZ_2b_2j3j", "3l_onZ_2b_4j5j", "4l"};
+vTStr SR_list_2 = SR_list;
 
 vTStr SR_list_3 = {"2lss_p", "2lss_m", "2lss_4t", "3l_offZ", "3l_onZ_2b_2j3j", "4l", "3l_onZ_1b", "3l_onZ_2b_4j5j"};
 
 vTStr SR_list_2lss = {"2lss_p", "2lss_m", "2lss_4t_p", "2lss_4t_m"};
 
-std::vector<std::string> kin_list = {"ht"};//{"lj0pt", "ptz"};
-
 std::unordered_map<std::string,std::vector<TString> > cat_groups {
     {"all",
       {
+        "2los_sf_ph_1j",
+        "2los_sf_ph_2j",
+        "2los_sf_ph_3j",
+        "2los_sf_ph_4j",
+        "2los_of_ph_1j",
+        "2los_of_ph_2j",
+        "2los_of_ph_3j",
+        "2los_of_ph_4j",
+        "2los_ph_CR_sf_Zg_1j",
+        "2los_ph_CR_sf_Zg_2j",
+        "2los_ph_CR_sf_Zg_3j",
+        "2los_ph_CR_sf_Zg_4j",
         "2lss_p_4j",
         "2lss_p_5j",
         "2lss_p_6j",
@@ -235,6 +281,33 @@ std::unordered_map<std::string,std::vector<TString> > cat_groups {
         "3l_m_offZ_2b_3j",
         "3l_m_offZ_2b_4j",
         "3l_m_offZ_2b_5j",
+      }
+    },
+
+    {"2los_sf_ph",
+      {
+        "2los_sf_ph_1j",
+        "2los_sf_ph_2j",
+        "2los_sf_ph_3j",
+        "2los_sf_ph_4j",
+      }
+    },
+
+    {"2los_of_ph",
+      {
+        "2los_of_ph_1j",
+        "2los_of_ph_2j",
+        "2los_of_ph_3j",
+        "2los_of_ph_4j",
+      }
+    },
+
+    {"2los_ph_CR_sf_Zg",
+      {
+        "2los_ph_CR_sf_Zg_1j",
+        "2los_ph_CR_sf_Zg_2j",
+        "2los_ph_CR_sf_Zg_3j",
+        "2los_ph_CR_sf_Zg_4j"
       }
     },
 };

--- a/Fitter/interface/PlotGroup.h
+++ b/Fitter/interface/PlotGroup.h
@@ -34,6 +34,24 @@ std::unordered_map<std::string,std::string> BIN_LABEL_MAP {
     {"4l","4\\ell"},
     {"3l_onZ_2b_2j3j","3\\ell \\text{ on-Z 2b 2j3j}"},
     {"3l_onZ_2b_4j5j","3\\ell \\text{ on-Z 2b 4j5j}"},
+    {"2los_sf_ph", "2\\ell \\text{os SF SR}"},
+    {"2los_of_ph", "2\\ell \\text{os OF SR}"},
+    {"2los_ph_CR_sf_Zg","2\\ell \\text{os SF Z}\\gamma \\, \\text{CR}"},
+
+    {"2los_sf_ph_1j" ,"1"},
+    {"2los_sf_ph_2j" ,"2"},
+    {"2los_sf_ph_3j" ,"3"},
+    {"2los_sf_ph_4j" ,"4"},
+
+    {"2los_of_ph_1j" ,"1"},
+    {"2los_of_ph_2j" ,"2"},
+    {"2los_of_ph_3j" ,"3"},
+    {"2los_of_ph_4j" ,"4"},
+
+    {"2los_ph_CR_sf_Zg_1j" ,"1"},
+    {"2los_ph_CR_sf_Zg_2j" ,"2"},
+    {"2los_ph_CR_sf_Zg_3j" ,"3"},
+    {"2los_ph_CR_sf_Zg_4j" ,"4"},
 
     {"2lss_p_4j"     ,"4"},
     {"2lss_p_5j"     ,"5"},
@@ -88,6 +106,21 @@ std::unordered_map<std::string,std::string> BIN_LABEL_MAP {
     {"4l_2j"         ,"2"},
     {"4l_3j"         ,"3"},
     {"4l_4j"         ,"4"},
+
+    {"2los_sf_ph_1j" ,"1"},
+    {"2los_sf_ph_2j" ,"2"},
+    {"2los_sf_ph_3j" ,"3"},
+    {"2los_sf_ph_4j" ,"4"},
+
+    {"2los_of_ph_1j" ,"1"},
+    {"2los_of_ph_2j" ,"2"},
+    {"2los_of_ph_3j" ,"3"},
+    {"2los_of_ph_4j" ,"4"},
+
+    {"2los_ph_CR_sf_Zg_1j" ,"1"},
+    {"2los_ph_CR_sf_Zg_2j" ,"2"},
+    {"2los_ph_CR_sf_Zg_3j" ,"3"},
+    {"2los_ph_CR_sf_Zg_4j" ,"4"},
 };
 
 std::unordered_map<std::string,std::string> BIN_LABEL_MAP_DIVIDED {
@@ -105,6 +138,9 @@ std::unordered_map<std::string,std::string> BIN_LABEL_MAP_DIVIDED {
     {"4l","4\\ell"},
     {"3l_onZ_2b_2j3j","\\splitline{3\\ell \\text{ on-Z}}{\\text{2b 2j3j}}"},
     {"3l_onZ_2b_4j5j","\\splitline{3\\ell \\text{ on-Z}}{\\text{2b 4j5j}}"},
+    {"2los_sf_ph", "2\\ell \\text{os SF SR}"},
+    {"2los_of_ph", "2\\ell \\text{os OF SR}"},
+    {"2los_ph_CR_sf_Zg","2\\ell \\text{os SF Z}\\gamma \\,\\text{CR}"},
 };
 
 struct PlotGroup {

--- a/Fitter/scripts/plot_maker.C
+++ b/Fitter/scripts/plot_maker.C
@@ -2105,11 +2105,13 @@ void make_overlay_sub_plots(
 
 // When calling this function, passing postfix as the arg. The postfix is used in the folder name like "SR_xxx" 
 void plot_maker(std::string postfix = "") {
-    std::string in_dir  = "/afs/crc.nd.edu/user/f/fyan2/macrotesting/CMSSW_10_2_13/src/EFTFit/Fitter/test/fit_results/";
-    std::string out_dir = "/afs/crc.nd.edu/user/f/fyan2/macrotesting/CMSSW_10_2_13/src/EFTFit/Fitter/test/fit_results/";
+    //The in_dir and out_dir can be same and can point to same area inside "test" dir. The out_dir is currently unused. 
+    //CAUTION: Hardcoded paths
+    std::string in_dir  = "/afs/crc.nd.edu/user/a/abasnet/CMSSW_10_2_13/src/EFTFit/Fitter/test/fit_results/";
+    std::string out_dir = "/afs/crc.nd.edu/user/a/abasnet/CMSSW_10_2_13/src/EFTFit/Fitter/test/fit_results/";
     
-    //TString fpath_datacard = "/afs/crc.nd.edu/user/f/fyan2/macrotesting/CMSSW_10_2_13/src/EFTFit/Fitter/test/card_ub/combinedcard.txt";
-    TString fpath_datacard = "/afs/crc.nd.edu/user/f/fyan2/macrotesting/CMSSW_10_2_13/src/EFTFit/Fitter/test/card_ht_7bins/combinedcard.txt";
+    //CAUTION: Hardcoded datacard path and name
+    TString fpath_datacard = "/afs/crc.nd.edu/user/a/abasnet/CMSSW_10_2_13/src/EFTFit/Fitter/test/top22006_wps/combinedcard.txt";
     //TString fpath_datacard = "/afs/crc.nd.edu/user/y/ywan2/important-test-scripts/combinedcard.txt";
 
     std::map<std::string,TString> ch_map = get_channel_map( fpath_datacard.Data(), true); // map from to long string jet subcategory name to the short channel name
@@ -2129,10 +2131,10 @@ void plot_maker(std::string postfix = "") {
         ch_map.insert(std::move(nodeHandler));
     }
     
-    // Plot options
-    bool incl_mega_plots = false;
+    // Plot options. Toggle this if you want mega plots or not
+    bool incl_mega_plots = true;
     bool incl_njet_plots = false;
-    bool incl_sub_plots  = true;
+    bool incl_sub_plots  = false;
     bool incl_sum_plots  = false;
     
     // Plot layout options
@@ -2163,7 +2165,7 @@ void plot_maker(std::string postfix = "") {
     
     std::string pData_path = TString::Format("%sSR_%s/", in_dir.c_str(), fit_type.c_str()).Data();
     std::vector<std::string> files = all_files(pData_path);
-    
+
     PlotData pData_raw = read_PlotData_from_file(files);
     PlotData pData;
     if (fit_type.find("ht") != -1) pData = pData_raw;
@@ -2172,7 +2174,8 @@ void plot_maker(std::string postfix = "") {
     // PlotData pData_arranged = rearrange(pData, ch_map, kin_map, SR_list_2); // Split onZ 2b
     PlotData pData_arranged = rearrange(pData, ch_map, kin_map, SR_list_2); // Don't split onZ 2b
     PlotData pData_arranged2 = rearrange(pData, ch_map, {}, SR_list);
-    PlotData pData_aggregated = aggregateDifferential(pData_arranged2);
+    //PlotData pData_aggregated = aggregateDifferential(pData_arranged2); //ORIGINALLY WHAT THE SCRIPT HAD
+    PlotData pData_aggregated = aggregateDifferential(pData_arranged); //MODIFIED BY Aashwin. kin_map is needed to map channels to kinematic diff. variable
     
     cout << pData.SR_name.size() << endl;
     cout << pData_arranged.SR_name.size() << endl;

--- a/Fitter/scripts/struct_maker.C
+++ b/Fitter/scripts/struct_maker.C
@@ -72,10 +72,14 @@ RooFitResult* load_fitresult(TString fpath, TString fr_key, TFile* f) {
 
 void struct_maker(int SR_selector) {
     //TFile* ws_file = TFile::Open("/scratch365/kmohrman/forFurong/ptz-lj0pt_fullR2_anatest18v07_withAutostats_withSys/ptz-lj0pt_fullR2_anatest18v07_withAutostats_withSys.root");
-    std::string in_dir = "/afs/crc.nd.edu/user/f/fyan2/macrotesting/CMSSW_10_2_13/src/EFTFit/Fitter/test/card_anatest25/";
-    std::string out_dir = "/afs/crc.nd.edu/user/f/fyan2/macrotesting/CMSSW_10_2_13/src/EFTFit/Fitter/test/fit_results/";
+    //std::string in_dir = "/afs/crc.nd.edu/user/f/fyan2/macrotesting/CMSSW_10_2_13/src/EFTFit/Fitter/test/card_anatest25/";
+    //std::string out_dir = "/afs/crc.nd.edu/user/f/fyan2/macrotesting/CMSSW_10_2_13/src/EFTFit/Fitter/test/fit_results/";
+    //CAUTION: Hardcoded paths
+    std::string in_dir = "/afs/crc.nd.edu/user/a/abasnet/CMSSW_10_2_13/src/EFTFit/Fitter/test/top22006_wps/";
+    std::string out_dir = "/afs/crc.nd.edu/user/a/abasnet/CMSSW_10_2_13/src/EFTFit/Fitter/test/fit_results/";
 
-    TString fpath_workspace = TString::Format("%s%s", in_dir.c_str(), "wps.root");
+    //CAUTION: Hardcoded workspace name
+    TString fpath_workspace = TString::Format("%s%s", in_dir.c_str(), "ptz-lj0pt_fullR2_anatest25v01_withAutostats_withSys.root");
     TFile* ws_file = TFile::Open(fpath_workspace);
     
     RooWorkspace* ws = (RooWorkspace*) ws_file->Get("w");
@@ -86,7 +90,7 @@ void struct_maker(int SR_selector) {
         AnalysisCategory::index_mapping.push_back(half_int);
     }
     AnalysisCategory::roo_counter = 0;
-    bool do_postfit = false; // true: do postfit, false: do prefit
+    bool do_postfit = true; // true: do postfit, false: do prefit
     
     //TString fpath_datacard = "/afs/crc.nd.edu/user/f/fyan2/macrotesting/CMSSW_10_2_13/src/EFTFit/Fitter/test/card_ub_2017/combinedcard.txt";  // hard-coded path for the datacard for now.
     TString fpath_datacard = TString::Format("%s%s", in_dir.c_str(), "combinedcard.txt");
@@ -111,7 +115,9 @@ void struct_maker(int SR_selector) {
     RooFitResult* postfit = nullptr;
     
     if (do_postfit) {
-        postfit = load_fitresult(in_dir + "multidimfit.root", FR_MDKEY, postfit_file);
+        //postfit = load_fitresult(in_dir + "multidimfit.root", FR_MDKEY, postfit_file);
+        //CAUTION: Hardcoded file name
+        postfit = load_fitresult(in_dir + "multidimfitmultidimfit.root", FR_MDKEY, postfit_file);
         ws->saveSnapshot("postfit_i",postfit->floatParsInit(),kTRUE);
         ws->saveSnapshot("postfit_f",postfit->floatParsFinal(),kTRUE);
     }
@@ -154,8 +160,6 @@ void struct_maker(int SR_selector) {
         file_name = file_path + file_name;
         std::string file_name_sum = TString::Format("SR%d_sum", idx).Data();
         file_name_sum = file_path_sum + file_name_sum;
-        
-        cout << "Output file: " << file_name << endl;
         
         file_names.push_back(file_name);
         


### PR DESCRIPTION
This is a simple PR that updates some header paths from combine necessary to run the postfit making scripts. I have also added tags reading `CAUTION: Hardcoded paths` or `CAUTION: Hardcoded files`, etc. to warn user to modify these paths using simple search functionality. These changes were tested to make post-fit plots for TOP-22-006 setup on May 9, 2025 and was verified to work.